### PR TITLE
Default volume 50% and --initial-volume argument

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,10 +1,3 @@
-[root]
-name = "librespot-protocol"
-version = "0.1.0"
-dependencies = [
- "protobuf 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
 [[package]]
 name = "aho-corasick"
 version = "0.6.3"
@@ -350,6 +343,13 @@ dependencies = [
  "librespot-core 0.1.0",
  "librespot-protocol 0.1.0",
  "linear-map 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "librespot-protocol"
+version = "0.1.0"
+dependencies = [
  "protobuf 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ target/release/librespot --username USERNAME --cache CACHEDIR --name DEVICENAME 
 | Option   |       | backend             | Audio backend to use. Use '?' to list options   | BACKEND     |
 | Option   |       | device              | Audio device to use. Use '?' to list options    | DEVICE      |
 | Option   |       | mixer               | Mixer to use                                    | MIXER       |
+| Option   |       | initial-volume      | Initial volume in %, once connected [0-100]     | VOLUME      |
 
 Taken from here:
 https://github.com/ComlOnline/librespot/blob/master/src/main.rs#L88

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ README.
 ## Building
 Rust 1.17.0 or later is required to build librespot.
 
-**If you are building librespot on macOS, the homebrew provided rust may fail due to the way in which homebrew installs rust. In this case, uninstall the homebrew version of rust and use [rustup](https://www.rustup.rs/), and librespot should then build.** 
+**If you are building librespot on macOS, the homebrew provided rust may fail due to the way in which homebrew installs rust. In this case, uninstall the homebrew version of rust and use [rustup](https://www.rustup.rs/), and librespot should then build.**
 
 It also requires a C, with portaudio.
 
@@ -43,7 +43,7 @@ cargo build --release
 A sample program implementing a headless Spotify Connect receiver is provided.
 Once you've built *librespot*, run it using :
 ```shell
-target/release/librespot --username USERNAME --cache CACHEDIR --name DEVICENAME
+target/release/librespot --username USERNAME --cache CACHEDIR --name DEVICENAME [--initial-volume 20]
 ```
 
 ## Discovery mode
@@ -63,7 +63,7 @@ target/release/librespot [...] --backend portaudio
 
 The following backends are currently available :
 - ALSA
-- PortAudio 
+- PortAudio
 - PulseAudio
 
 ## Cross-compiling
@@ -108,4 +108,3 @@ https://gitter.im/sashahilton00/spotify-connect-resources
 
 ## License
 Everything in this repository is licensed under the MIT license.
-

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -121,4 +121,5 @@ impl Default for PlayerConfig {
 pub struct ConnectConfig {
     pub name: String,
     pub device_type: DeviceType,
+    pub volume: i32,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,7 +101,7 @@ fn setup(args: &[String]) -> Setup {
         .optopt("", "backend", "Audio backend to use. Use '?' to list options", "BACKEND")
         .optopt("", "device", "Audio device to use. Use '?' to list options", "DEVICE")
         .optopt("", "mixer", "Mixer to use", "MIXER")
-        .optopt("", "initial-volume", "Initial volume in %, once connected", "VOLUME");
+        .optopt("", "initial-volume", "Initial volume in %, once connected (must be from 0 to 100)", "VOLUME");
 
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
@@ -136,7 +136,12 @@ fn setup(args: &[String]) -> Setup {
         .expect("Invalid mixer");
     let initial_volume;
     if matches.opt_present("initial-volume"){
-        initial_volume = matches.opt_str("initial-volume").unwrap().parse::<i32>().unwrap()* 0xFFFF as i32 / 100 ;
+        if matches.opt_str("initial-volume").unwrap().parse::<i32>().is_ok(){
+            initial_volume = matches.opt_str("initial-volume").unwrap().parse::<i32>().unwrap()* 0xFFFF as i32 / 100 ;
+            }
+        else {
+            initial_volume = 0x8000 as i32;
+            }
         }
     else{
         initial_volume = 0x8000 as i32;

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,12 +137,21 @@ fn setup(args: &[String]) -> Setup {
     let initial_volume;
     if matches.opt_present("initial-volume"){
         if matches.opt_str("initial-volume").unwrap().parse::<i32>().is_ok(){
-            initial_volume = matches.opt_str("initial-volume").unwrap().parse::<i32>().unwrap()* 0xFFFF as i32 / 100 ;
+            if matches.opt_str("initial-volume").unwrap().parse::<i32>().unwrap() < 0 {
+                initial_volume = 0 as i32;
             }
+            else if matches.opt_str("initial-volume").unwrap().parse::<i32>().unwrap() > 100{
+                initial_volume = 0xFFFF as i32;
+            }
+            else{
+                initial_volume = matches.opt_str("initial-volume").unwrap().parse::<i32>().unwrap()* 0xFFFF as i32 / 100 ;
+            }
+
+        }
         else {
             initial_volume = 0x8000 as i32;
-            }
         }
+    }
     else{
         initial_volume = 0x8000 as i32;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,7 +100,8 @@ fn setup(args: &[String]) -> Setup {
         .optflag("", "disable-discovery", "Disable discovery mode")
         .optopt("", "backend", "Audio backend to use. Use '?' to list options", "BACKEND")
         .optopt("", "device", "Audio device to use. Use '?' to list options", "DEVICE")
-        .optopt("", "mixer", "Mixer to use", "MIXER");
+        .optopt("", "mixer", "Mixer to use", "MIXER")
+        .optopt("", "initial-volume", "Initial volume in %, once connected", "VOLUME");
 
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
@@ -133,6 +134,14 @@ fn setup(args: &[String]) -> Setup {
     let mixer_name = matches.opt_str("mixer");
     let mixer = mixer::find(mixer_name.as_ref())
         .expect("Invalid mixer");
+    let initial_volume;
+    if matches.opt_present("initial-volume"){
+        initial_volume = matches.opt_str("initial-volume").unwrap().parse::<i32>().unwrap()* 0xFFFF as i32 / 100 ;
+        }
+    else{
+        initial_volume = 0x8000 as i32;
+        }
+    info!("Volume \"{}\" !", initial_volume);
 
     let name = matches.opt_str("name").unwrap();
     let use_audio_cache = !matches.opt_present("disable-audio-cache");
@@ -180,6 +189,7 @@ fn setup(args: &[String]) -> Setup {
         ConnectConfig {
             name: name,
             device_type: device_type,
+            volume: initial_volume,
         }
     };
 
@@ -342,4 +352,3 @@ fn main() {
 
     core.run(Main::new(handle, setup(&args))).unwrap()
 }
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,27 +135,32 @@ fn setup(args: &[String]) -> Setup {
     let mixer = mixer::find(mixer_name.as_ref())
         .expect("Invalid mixer");
     let initial_volume;
+    // check if initial-volume argument is present
     if matches.opt_present("initial-volume"){
+        // check if value is a number
         if matches.opt_str("initial-volume").unwrap().parse::<i32>().is_ok(){
+            // check if value is in [0-100] range, otherwise put the bound values
             if matches.opt_str("initial-volume").unwrap().parse::<i32>().unwrap() < 0 {
                 initial_volume = 0 as i32;
             }
             else if matches.opt_str("initial-volume").unwrap().parse::<i32>().unwrap() > 100{
                 initial_volume = 0xFFFF as i32;
             }
+            // checks ok
             else{
                 initial_volume = matches.opt_str("initial-volume").unwrap().parse::<i32>().unwrap()* 0xFFFF as i32 / 100 ;
             }
-
         }
+        // if value is not a number use default value (50%)
         else {
             initial_volume = 0x8000 as i32;
         }
     }
+    // if argument not present use default values (50%)
     else{
         initial_volume = 0x8000 as i32;
         }
-    info!("Volume \"{}\" !", initial_volume);
+    debug!("Volume \"{}\" !", initial_volume);
 
     let name = matches.opt_str("name").unwrap();
     let use_audio_cache = !matches.opt_present("disable-audio-cache");

--- a/src/spirc.rs
+++ b/src/spirc.rs
@@ -142,7 +142,7 @@ impl Spirc {
 
         let (cmd_tx, cmd_rx) = mpsc::unbounded();
 
-        let volume = 0x3333;
+        let volume = 0x8000;
         let device = initial_device_state(config, volume);
         mixer.set_volume(volume);
 

--- a/src/spirc.rs
+++ b/src/spirc.rs
@@ -142,7 +142,7 @@ impl Spirc {
 
         let (cmd_tx, cmd_rx) = mpsc::unbounded();
 
-        let volume = 0x8000;
+        let volume = 0x3333;
         let device = initial_device_state(config, volume);
         mixer.set_volume(volume);
 

--- a/src/spirc.rs
+++ b/src/spirc.rs
@@ -142,9 +142,9 @@ impl Spirc {
 
         let (cmd_tx, cmd_rx) = mpsc::unbounded();
 
-        let volume = 0x8000;
+        let volume = config.volume as u16;
         let device = initial_device_state(config, volume);
-        mixer.set_volume(volume);
+        mixer.set_volume(volume as u16);
 
         let mut task = SpircTask {
             player: player,

--- a/src/spirc.rs
+++ b/src/spirc.rs
@@ -142,7 +142,7 @@ impl Spirc {
 
         let (cmd_tx, cmd_rx) = mpsc::unbounded();
 
-        let volume = 0xFFFF;
+        let volume = 0x8000;
         let device = initial_device_state(config, volume);
         mixer.set_volume(volume);
 


### PR DESCRIPTION
You can set initial volume to a value in [0-100]. 
e.g. 
`target/release/librespot --name DEVICENAME --initial-volume 40`
If not present the default volume will be 50% instead of 100%. IMO this allows user to have a better control: you can turn up and down the volume (before you can only turn it down).